### PR TITLE
Fix b2 lib for application keys

### DIFF
--- a/b2/src/lib.rs
+++ b/b2/src/lib.rs
@@ -87,7 +87,7 @@ impl Session {
             })
             .collect::<Result<Vec<&str>>>()?;
 
-        if !capes.iter().any(|c| *c == "listKeys") {
+        if !capes.iter().any(|c| *c == "listFiles") {
             return Err(bad("credentials can not list files"));
         }
         if !capes.iter().any(|c| *c == "readFiles") {


### PR DESCRIPTION
Fix to check for listFiles rather than listKeys (only available to master keys)